### PR TITLE
Fix: timer preemption

### DIFF
--- a/inc/timer.h
+++ b/inc/timer.h
@@ -63,10 +63,12 @@ void timer_check(void);
 void delay(uint16_t ms);
 
 /** Returns the number of milliseconds since booting.
+ *  @warning: can only be used from interrupt handlers with LOWER priority than priority 0. (priority > 0)
  */
 uint32_t get_boot_time_ms(void);
 
 /** Returns the number of microseconds since booting.
+ *  @warning: can only be used from interrupt handlers with LOWER priority than priority 0. (priority > 0)
  */
 uint32_t get_boot_time_us(void);
 

--- a/src/camera.c
+++ b/src/camera.c
@@ -292,6 +292,7 @@ void camera_transport_transfer_done_fn(void *usr, const void *buffer, size_t siz
 		}
 	} else {
 		// no frame currently as the target frame. it must be the beginning of a new frame then!
+		volatile uint32_t fr_timestamp = get_boot_time_us();
 		// update the sensor: (this might trigger some I2C transfers)
 		ctx->sensor->notify_readout_start(ctx->sensor->usr);
 		// get current sensor parameter:
@@ -333,7 +334,7 @@ void camera_transport_transfer_done_fn(void *usr, const void *buffer, size_t siz
 		}
 		// initialize the target buffer:
 		if (ctx->cur_frame_target_buf != NULL) {
-			ctx->cur_frame_target_buf->timestamp    = get_boot_time_us();
+			ctx->cur_frame_target_buf->timestamp    = fr_timestamp;
 			ctx->cur_frame_target_buf->frame_number = ctx->cur_frame_number;
 			ctx->cur_frame_target_buf->param        = ctx->cur_frame_param;
 			// write data to it: (at position 0)

--- a/src/dcmi.c
+++ b/src/dcmi.c
@@ -192,7 +192,7 @@ static void dcmi_dma_it_init() {
 
 	/* Enable the DCMI global Interrupt */
 	NVIC_InitStructure.NVIC_IRQChannel = DCMI_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
 	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 2;
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);
@@ -201,7 +201,7 @@ static void dcmi_dma_it_init() {
 	
 	/* Enable the DMA global Interrupt */
 	NVIC_InitStructure.NVIC_IRQChannel = DMA2_Stream1_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
 	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 2;
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -106,13 +106,13 @@ void i2c_init() {
 	NVIC_InitTypeDef NVIC_InitStructure, NVIC_InitStructure2;
 
 	NVIC_InitStructure.NVIC_IRQChannel = I2C1_EV_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 2;
 	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);
 
 	NVIC_InitStructure2.NVIC_IRQChannel = I2C1_ER_IRQn;
-	NVIC_InitStructure2.NVIC_IRQChannelPreemptionPriority = 1;
+	NVIC_InitStructure2.NVIC_IRQChannelPreemptionPriority = 2;
 	NVIC_InitStructure2.NVIC_IRQChannelSubPriority = 0;
 	NVIC_InitStructure2.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure2);

--- a/src/sonar.c
+++ b/src/sonar.c
@@ -224,7 +224,7 @@ void sonar_config(void)
 
 	/* Enable the USARTx Interrupt */
 	NVIC_InitStructure.NVIC_IRQChannel = UART4_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 2;
 	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);

--- a/src/timer.c
+++ b/src/timer.c
@@ -166,6 +166,8 @@ void timer_init(void)
 		LEDOn(LED_ERR);
 		while (1);
 	}
+	/* set highest priority: */
+	NVIC_SetPriority(SysTick_IRQn, 0);
 }
 
 uint32_t get_boot_time_ms(void)

--- a/src/usart.c
+++ b/src/usart.c
@@ -295,7 +295,7 @@ void usart_init(void)
 
 	/* Enable the USARTx Interrupt */
 	NVIC_InitStructure.NVIC_IRQChannel = USART2_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 2;
 	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);

--- a/src/usb_bsp.c
+++ b/src/usb_bsp.c
@@ -87,7 +87,7 @@ void USB_OTG_BSP_EnableInterrupt(USB_OTG_CORE_HANDLE *pdev)
 
 	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
 	NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 2;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 3;
 	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 3;
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);


### PR DESCRIPTION
The usage of get_boot_time_us() in the camera interrupt handler caused issues where sometimes it would return a timestamp that is 1ms in the past. The result is that some frames deltas would be reported as 1ms too short while the next frame after such an incident would be 1ms too long.

After this fix the frame timing jitter is in the order of a few microseconds.

I would have liked to fix it without re-assigning interrupt priorities but it is not possible because I didn't see a way to check the pending flag of the SysTick exception. (There is only an active flag)

@kevinmehall 