### PR TITLE
Feature: Maximum velocity calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ set(PX4FLOW_HDRS
     )
 
 set(PX4FLOW_SRC
-    inc/camera.c
+    src/camera.c
     src/communication.c
     src/dcmi.c
     src/debug.c

--- a/inc/flow.h
+++ b/inc/flow.h
@@ -52,6 +52,11 @@ typedef struct _flow_klt_image {
 	uint32_t meta;
 } flow_klt_image;
 
+typedef struct _flow_capability {
+	float max_x_px_frame;
+	float max_y_px_frame;
+} flow_capability;
+
 /**
  *  @brief Computes pixel flow from image1 to image2
  *  Searches the corresponding position in the new image (image2) of max. 64 pixels from the old image (image1).
@@ -66,6 +71,12 @@ typedef struct _flow_klt_image {
  */
 uint16_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rate, float z_rate,
 					  flow_raw_result *out, uint16_t max_out);
+
+/*
+ * Returns the capability of the flow algorithm.
+ * @param cap Receives the capability.
+ */
+void get_flow_capability(flow_capability *cap);
 
 /**
  *	Preprocesses the image for use with compute_klt. 
@@ -90,6 +101,12 @@ void klt_preprocess_image(uint8_t *image, flow_klt_image *klt_image);
  */
 uint16_t compute_klt(flow_klt_image *image1, flow_klt_image *image2, float x_rate, float y_rate, float z_rate,
 					 flow_raw_result *out, uint16_t max_out);
+
+/*
+ * Returns the capability of the KLT algorithm.
+ * @param cap Receives the capability.
+ */
+void get_flow_klt_capability(flow_capability *cap);
 
 /**
 * 

--- a/inc/i2c.h
+++ b/inc/i2c.h
@@ -43,6 +43,8 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
+#include "flow.h"
+
 #define I2C1_OWNADDRESS_1_BASE 0x42 //7bit base address
 /**
  * @brief  Configures I2C1 for communication as a slave (default behaviour for STM32F)
@@ -50,7 +52,7 @@
 
 void i2c_init(void);
 void update_TX_buffer(float dt, float x_rate, float y_rate, float z_rate, int16_t gyro_temp,
-					  uint8_t qual, float pixel_flow_x, float pixel_flow_y, float rad_per_pixel,
+					  uint8_t qual, float pixel_flow_x, float pixel_flow_y, const flow_capability *flow_cap, float rad_per_pixel,
 					  bool distance_valid, float ground_distance, uint32_t distance_age);
 char i2c_get_ownaddress1(void);
 #endif /* I2C_H_ */

--- a/inc/result_accumulator.h
+++ b/inc/result_accumulator.h
@@ -37,6 +37,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "flow.h"
 
 typedef struct _result_accumulator_ctx {
 	struct _last {
@@ -49,6 +50,9 @@ typedef struct _result_accumulator_ctx {
 		uint8_t qual;				///< The quality output of the flow algorithm.
 		float pixel_flow_x;			///< The measured x-flow in the current image in pixel. Sensor linear motion along the positive X axis induces a negative flow.
 		float pixel_flow_y;			///< The measured y-flow in the current image in pixel. Sensor linear motion along the positive Y axis induces a negative flow.
+		flow_capability flow_cap;	///< The flow capability.
+		float flow_cap_mvx_rad;		///< The maximum velocity the last flow result could measure. In rad / s. (x-direction)
+		float flow_cap_mvy_rad;		///< The maximum velocity the last flow result could measure. In rad / s. (y-direction)
 		float flow_x_rad;			///< Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)
 		float flow_y_rad;			///< Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)
 		float flow_x_m;				///< The measured x-flow in the current image in meters.
@@ -63,6 +67,10 @@ typedef struct _result_accumulator_ctx {
 	float rad_flow_y_accu;
 	float m_flow_x_accu;
 	float m_flow_y_accu;
+	float flow_cap_mvx_rad;			/**< The maximum velocity that could be measured by all datasets together in one accumulation period. 
+									 *   This is the minimum of all max velocities. In rad / s. */
+	float flow_cap_mvy_rad;			/**< The maximum velocity that could be measured by all datasets together in one accumulation period. 
+									 *   This is the minimum of all max velocities. In rad / s. */
 	uint8_t min_quality;
 	uint16_t data_count;
 	uint16_t valid_data_count;
@@ -136,7 +144,7 @@ void result_accumulator_init(result_accumulator_ctx *ctx);
  *	@param distance_age Age of the distance measurement in us.
  */
 void result_accumulator_feed(result_accumulator_ctx *ctx, float dt, float x_rate, float y_rate, float z_rate, int16_t gyro_temp,
-							 uint8_t qual, float pixel_flow_x, float pixel_flow_y, float rad_per_pixel,
+							 uint8_t qual, float pixel_flow_x, float pixel_flow_y, const flow_capability *flow_cap, float rad_per_pixel,
 							 bool distance_valid, float ground_distance, uint32_t distance_age);
 
 /**	Recalculates the output values of the result_accumulator. Call this before using any of the output values.

--- a/src/flow.c
+++ b/src/flow.c
@@ -390,6 +390,13 @@ static inline uint32_t compute_sad_8x8(uint8_t *image1, uint8_t *image2, uint16_
 	return acc;
 }
 
+void get_flow_capability(flow_capability *cap) {
+	const uint16_t search_size = SEARCH_SIZE;
+	
+	cap->max_x_px_frame = search_size + 0.5;
+	cap->max_y_px_frame = search_size + 0.5;
+}
+
 uint16_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rate, float z_rate,
 					  flow_raw_result *out, uint16_t max_out)
 {
@@ -537,6 +544,13 @@ void klt_preprocess_image(uint8_t *image, flow_klt_image *klt_image) {
 			}
 		}
 	}
+}
+
+void get_flow_klt_capability(flow_capability *cap) {
+	uint16_t topPyrStep = 1 << (PYR_LVLS - 1);
+
+	cap->max_x_px_frame = topPyrStep * 2;
+	cap->max_y_px_frame = topPyrStep * 2;
 }
 
 uint16_t compute_klt(flow_klt_image *image1, flow_klt_image *image2, float x_rate, float y_rate, float z_rate,

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -223,7 +223,7 @@ void I2C1_ER_IRQHandler(void) {
 }
 
 void update_TX_buffer(float dt, float x_rate, float y_rate, float z_rate, int16_t gyro_temp,
-					  uint8_t qual, float pixel_flow_x, float pixel_flow_y, float rad_per_pixel,
+					  uint8_t qual, float pixel_flow_x, float pixel_flow_y, const flow_capability *flow_cap, float rad_per_pixel,
 					  bool distance_valid, float ground_distance, uint32_t distance_age) {
 	static result_accumulator_ctx accumulator;
 	static bool initialized = false;
@@ -241,7 +241,7 @@ void update_TX_buffer(float dt, float x_rate, float y_rate, float z_rate, int16_
 
 	/* feed the accumulator and recalculate */
 	result_accumulator_feed(&accumulator, dt, x_rate, y_rate, z_rate, gyro_temp,
-							qual, pixel_flow_x, pixel_flow_y, rad_per_pixel, 
+							qual, pixel_flow_x, pixel_flow_y, flow_cap, rad_per_pixel, 
 							distance_valid, ground_distance, distance_age);
 
 	result_accumulator_output_flow output_flow;

--- a/src/main.c
+++ b/src/main.c
@@ -309,9 +309,6 @@ int main(void)
 			}
 		}
 
-		/* calculate focal_length in pixel */
-		const float focal_length_px = (global_data.param[PARAM_FOCAL_LENGTH_MM]) / (4.0f * 0.006f); //original focal lenght: 12mm pixelsize: 6um, binning 4 enabled
-
 		/* new gyroscope data */
 		float x_rate_sensor, y_rate_sensor, z_rate_sensor;
 		int16_t gyro_temp;
@@ -393,20 +390,40 @@ int main(void)
 			}
 		}
 		
-		float frame_dt = (frames[0]->timestamp - frames[1]->timestamp) * 0.000001f;
-
-		/* compute gyro rate in pixels and change to image coordinates */
-		float x_rate_px = - y_rate * (focal_length_px * frame_dt);
-		float y_rate_px =   x_rate * (focal_length_px * frame_dt);
-		float z_rate_fr = - z_rate * frame_dt;
-
-		/* compute optical flow in pixels */
+		const float frame_dt = (frames[0]->timestamp - frames[1]->timestamp) * 0.000001f;
+		
+		/* calculate focal_length in pixel */
+		const float focal_length_px = (global_data.param[PARAM_FOCAL_LENGTH_MM]) / 
+									  ((float)frames[0]->param.p.binning * 0.006f);	// pixel-size: 6um
+		
+		/* extract the raw flow from the images: */
 		flow_raw_result flow_rslt[32];
 		uint16_t flow_rslt_count = 0;
-		if (!use_klt) {
-			flow_rslt_count = compute_flow(frames[1]->buffer, frames[0]->buffer, x_rate_px, y_rate_px, z_rate_fr, flow_rslt, 32);
+		/* make sure both images are taken with same binning mode: */
+		if (frames[0]->param.p.binning == frames[1]->param.p.binning) {
+			/* compute gyro rate in pixels and change to image coordinates */
+			float x_rate_px = - y_rate * (focal_length_px * frame_dt);
+			float y_rate_px =   x_rate * (focal_length_px * frame_dt);
+			float z_rate_fr = - z_rate * frame_dt;
+
+			/* compute optical flow in pixels */
+			if (!use_klt) {
+				flow_rslt_count = compute_flow(frames[1]->buffer, frames[0]->buffer, x_rate_px, y_rate_px, z_rate_fr, 
+											   flow_rslt, sizeof(flow_rslt) / sizeof(flow_rslt[0]));
+			} else {
+				flow_rslt_count =  compute_klt(klt_images[1], klt_images[0],         x_rate_px, y_rate_px, z_rate_fr, 
+											   flow_rslt, sizeof(flow_rslt) / sizeof(flow_rslt[0]));
+			}
 		} else {
-			flow_rslt_count =  compute_klt(klt_images[1], klt_images[0], x_rate_px, y_rate_px, z_rate_fr, flow_rslt, 32);
+			/* no result for this frame. */
+			flow_rslt_count = 0;
+		}
+		/* determine capability: */
+		flow_capability flow_rslt_cap;
+		if (!use_klt) {
+			get_flow_capability(&flow_rslt_cap);
+		} else {
+			get_flow_klt_capability(&flow_rslt_cap);
 		}
 
 		/* calculate flow value from the raw results */
@@ -461,13 +478,13 @@ int main(void)
 		/* update I2C transmit buffer */
 		update_TX_buffer(frame_dt, 
 						 x_rate, y_rate, z_rate, gyro_temp, 
-						 qual, pixel_flow_x, pixel_flow_y, 1.0f / focal_length_px, 
+						 qual, pixel_flow_x, pixel_flow_y, &flow_rslt_cap, 1.0f / focal_length_px, 
 						 distance_valid, ground_distance, get_time_delta_us(get_sonar_measure_time()));
 
 		/* accumulate the results */
 		result_accumulator_feed(&mavlink_accumulator, frame_dt, 
 								x_rate, y_rate, z_rate, gyro_temp, 
-								qual, pixel_flow_x, pixel_flow_y, 1.0f / focal_length_px, 
+								qual, pixel_flow_x, pixel_flow_y, &flow_rslt_cap, 1.0f / focal_length_px, 
 								distance_valid, ground_distance, get_time_delta_us(get_sonar_measure_time()));
 
 		uint32_t computaiton_time_us = get_time_delta_us(start_computations);


### PR DESCRIPTION
Implemented calculating the maximum possible velocity calculation.

The result accumulation logic is finished and stores the current value in the flow_cap_mvx_rad and flow_cap_mvy_rad variables. I used the min function to accumulate the maximum velocity because the weakest link in each accumulation period sets the maximum possible velocity which can be measured.

We need to define a format for outputting the values.

A detail that we discovered on the testbench:
It depends on the texture of the ground whether the algorithm can actually go up to the predicted maximum. On easy to track ground (grass for example) it will go up to the limit until it starts to output quality zero. On other textures it will start to drop out earlier. (Like 80%, I didn't do any exhaustive tests yet). Derating the maximum velocity is probably necessary.

So far when the actual ground velocity exceeds the maximum measurable velocity it will not produce wrong output. (It outputs quality 0 if velocity exceeds limits)